### PR TITLE
Added parenthesis to fix thread call

### DIFF
--- a/A6/simulator.py
+++ b/A6/simulator.py
@@ -242,7 +242,7 @@ class Simulator(object):
 			def ask():
 				q.put( list(self._players[pId].move(self._pubStat[pId])) )
 
-			p = multiprocessing.Process(target=ask)
+			p = multiprocessing.Process(target=ask())
 			p.start()
 			moves = q.get(timeout = self.params.moveTimeout)
 


### PR DESCRIPTION
Added parenthesis to the following code `p= multiprocessing.Process(target=ask)` -> `p= multiprocessing.Process(target=ask())`, so the function can be properly called from the thread. 